### PR TITLE
Fix/statistics zero usage

### DIFF
--- a/custom_components/homewizard_cloud_watermeter/coordinator.py
+++ b/custom_components/homewizard_cloud_watermeter/coordinator.py
@@ -64,7 +64,7 @@ class HomeWizardCloudDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning("No data received for watermeter device.")
                 continue
 
-            if not stats_yesterday or not stats_yesterday or "values" not in stats_today or "values" not in stats_yesterday:
+            if not stats_yesterday or "values" not in stats_today or "values" not in stats_yesterday:
                 _LOGGER.warning("No yesterday data received for watermeter device.")
                 continue
 

--- a/custom_components/homewizard_cloud_watermeter/coordinator.py
+++ b/custom_components/homewizard_cloud_watermeter/coordinator.py
@@ -54,7 +54,7 @@ class HomeWizardCloudDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Sanitize the identifier for Home Assistant's use
             # This will be used for statistic_id, unique_id, and device_id
-            device['sanitized_identifier'] = device["identifier"].replace('/', '_')
+            device["sanitized_identifier"] = device["identifier"].replace('/', '_')
 
             # Retrieve device data
             stats_today = await self.api.async_get_tsdb_data(now, self.hass.config.time_zone, device["identifier"])
@@ -163,10 +163,6 @@ class HomeWizardCloudDataUpdateCoordinator(DataUpdateCoordinator):
                 continue
 
             usage = hourly_data[hour]
-
-            # Ignore hours without water usage
-            if usage == 0:
-                continue
 
             cumulative_sum += usage
 

--- a/custom_components/homewizard_cloud_watermeter/sensor.py
+++ b/custom_components/homewizard_cloud_watermeter/sensor.py
@@ -79,7 +79,7 @@ class HomeWizardDailyTotalSensor(HomeWizardBaseSensor, SensorEntity):
         """Return the state of the sensor as a float."""
         daily_total = self.coordinator.data.get(self._sanitized_identifier)["daily_total"]
 
-        if not daily_total:
+        if daily_total is None:
             return None
 
         try:


### PR DESCRIPTION
Fixes multiple edge cases in statistics handling:
zero-usage hours, daily total reporting when value is 0,
and redundant yesterday data checks.

Also extract pure data processing logic (aggregate_hourly, find_baseline_sum, build_stat_data) into helpers.py with no Home Assistant dependency, and add 14 pytest unit tests covering aggregation, baseline lookup, cumulative sums, and the late-arriving cloud data scenario. Add .gitignore.

#5 