### PR TITLE
Always register external statistic metadata, even without new data points

### DIFF
--- a/custom_components/homewizard_cloud_watermeter/coordinator.py
+++ b/custom_components/homewizard_cloud_watermeter/coordinator.py
@@ -194,7 +194,9 @@ class HomeWizardCloudDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             )
 
-        if stat_data:
-            async_add_external_statistics(self.hass, metadata, stat_data)
+        # Always register the metadata, even with no new data points, so the
+        # statistic is immediately selectable in the Energy dashboard instead
+        # of waiting for the first hour with non-zero usage.
+        async_add_external_statistics(self.hass, metadata, stat_data)
 
         return cumulative_sum


### PR DESCRIPTION
Previously, the external statistic was only registered once there was at least one hour with non-zero water usage, which could make it unselectable in the Energy dashboard right after setup.

Ref #9 