### PR TITLE
Fix smoke test: run it as a standalone script outside pytest

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - run: pip install -r requirements_test.txt
-      - run: pytest tests/test_smoke.py -v
+      - run: pip install aiohttp async_timeout
+      - run: python tests/smoke.py
         env:
           HW_EMAIL: ${{ secrets.HW_EMAIL }}
           HW_PASSWORD: ${{ secrets.HW_PASSWORD }}

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -1,35 +1,45 @@
 """Smoke test against the real HomeWizard cloud API.
 
-Verifies the API contract the integration relies on still holds (auth,
-locations, device list, TSDB shape). Only runs when HW_EMAIL/HW_PASSWORD
-are set in the environment — i.e. the scheduled CI job — and is skipped
-everywhere else, so the regular test suite stays offline.
+Standalone script, deliberately outside pytest: the HA test plugin
+restricts sockets to localhost, and the API client only needs aiohttp
+anyway. Run by the scheduled smoke workflow with HW_EMAIL/HW_PASSWORD
+set; verifies the API contract the integration relies on still holds
+(auth, locations, device list, TSDB shape).
 """
+import asyncio
+import importlib.util
 import os
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import aiohttp
-import pytest
 
-from custom_components.homewizard_cloud_watermeter.api import HomeWizardCloudApi
-
-pytestmark = pytest.mark.skipif(
-    not (os.environ.get("HW_EMAIL") and os.environ.get("HW_PASSWORD")),
-    reason="HW_EMAIL/HW_PASSWORD not set",
+# Load api.py directly: importing the package would pull homeassistant
+# through custom_components/homewizard_cloud_watermeter/__init__.py.
+_api_path = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components" / "homewizard_cloud_watermeter" / "api.py"
 )
+_spec = importlib.util.spec_from_file_location("hw_api", _api_path)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+HomeWizardCloudApi = _module.HomeWizardCloudApi
 
 
-async def test_real_api_contract(socket_enabled):
+async def main():
     async with aiohttp.ClientSession() as session:
         api = HomeWizardCloudApi(
             os.environ["HW_EMAIL"], os.environ["HW_PASSWORD"], session, "smoke-test"
         )
 
         assert await api.async_authenticate() is True, "authentication failed"
+        print("auth: ok")
 
         locations = await api.async_get_locations()
         assert locations, "no locations returned"
         assert "id" in locations[0], "location shape changed: missing 'id'"
+        print(f"locations: ok ({len(locations)})")
 
         devices_data = await api.async_get_devices(locations[0]["id"])
         assert devices_data and "errors" not in devices_data, "device query failed"
@@ -40,6 +50,7 @@ async def test_real_api_contract(socket_enabled):
         device = watermeters[0]
         assert "identifier" in device
         assert "onlineState" in device
+        print(f"devices: ok ({len(watermeters)} watermeter)")
 
         yesterday = datetime.now() - timedelta(days=1)
         stats = await api.async_get_tsdb_data(
@@ -54,3 +65,10 @@ async def test_real_api_contract(socket_enabled):
         assert "water" in entry, "TSDB entry shape changed: missing 'water'"
         # 'time' must stay parseable by the coordinator
         datetime.fromisoformat(entry["time"])
+        print(f"tsdb: ok ({len(stats['values'])} values)")
+
+
+if __name__ == "__main__":
+    if not (os.environ.get("HW_EMAIL") and os.environ.get("HW_PASSWORD")):
+        sys.exit("HW_EMAIL/HW_PASSWORD not set")
+    asyncio.run(main())


### PR DESCRIPTION
The first real run of the smoke workflow failed: `pytest-homeassistant-custom-component` restricts sockets to `127.0.0.1` via pytest-socket, and the `socket_enabled` fixture only re-enables sockets without lifting the host restriction — so the test could never reach the real HomeWizard API (`A test tried to use socket.socket.connect() with host "34.107.212.62" (allowed: "127.0.0.1")`).

The API client only depends on aiohttp, so the smoke test is now a plain script (`tests/smoke.py`, no `test_` prefix — pytest no longer collects it, the regular suite stays fully offline). Side benefit: the job installs `aiohttp` + `async_timeout` instead of the whole HomeAssistant stack, dropping ~80s of pip backtracking.

Verified: script exits with "HW_EMAIL/HW_PASSWORD not set" without credentials; regular suite still 13 passed.